### PR TITLE
add Podman guide to navigation so discoverable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .svelte-kit
 /build
 /.venv
+CLAUDE.md

--- a/docs/setup-sensor/README.md
+++ b/docs/setup-sensor/README.md
@@ -28,6 +28,7 @@ The best sensor device for you depends on your specific needs:
 - [Raspberry Pi](/docs/setup-sensor/raspberry-pi.md)
 - [OpenWrt](/docs/setup-sensor/linux/openwrt.md)
 - [Docker](/docs/setup-sensor/docker.md)
+- [Podman](/docs/setup-sensor/podman.md)
 - [Home Assistant](/docs/setup-sensor/home-assistant.md)
 - [Proxmox](/docs/setup-sensor/proxmox.md)
 - [Steam Deck](/docs/setup-sensor/steam-deck.md)

--- a/navigation.md
+++ b/navigation.md
@@ -21,6 +21,7 @@
 - [Raspberry Pi](/docs/setup-sensor/raspberry-pi.md)
 - [OpenWrt](/docs/setup-sensor/linux/openwrt.md)
 - [Docker](/docs/setup-sensor/docker.md)
+- [Podman](/docs/setup-sensor/podman.md)
 - [Home Assistant](/docs/setup-sensor/home-assistant.md)
 - [Proxmox](/docs/setup-sensor/proxmox.md)
 - [Steam Deck](/docs/setup-sensor/steam-deck.md)


### PR DESCRIPTION
# Pull Request

## What changes have you made?

I added links to podman.md to navigation.md and setup-sensor/README.md

## Why are these changes helpful?

The Podman guide was not previously discoverable on orb.net/docs

## Related issues or considerations

#2 

## Checklist

- [x] Documentation is clear and understandable
- [x] No broken links or images
- [x] Follows project style and formatting
- [x] If scripts were modified/included, they have been tested and work as expected

## Additional notes

N/A

Please wait for feedback from the maintainers before merging.
