### PR TITLE
delete missing podman image reference

### DIFF
--- a/docs/setup-sensor/podman.md
+++ b/docs/setup-sensor/podman.md
@@ -4,7 +4,6 @@ shortTitle: Podman Quadlet
 metaDescription: Run the Orb sensor as a Podman container managed by a systemd quadlet on any compatible system.
 section: setup-sensor
 layout: guides
-imageUrl: ../../images/devices/podman.png
 subtitle: 'Difficulty: Intermediate 🧑‍🔬'
 ---
 


### PR DESCRIPTION
# Pull Request

## What changes have you made?

Removed reference to podman.png image that does not exist

## Why are these changes helpful?

Prevents building orb.net docs

## Related issues or considerations

N/A

## Checklist

- [x] Documentation is clear and understandable
- [x] No broken links or images
- [x] Follows project style and formatting
- [x] If scripts were modified/included, they have been tested and work as expected

## Additional notes

N/A

Please wait for feedback from the maintainers before merging.
