### PR TITLE
Add missing systemd timer for Podman

### DIFF
--- a/docs/setup-sensor/podman.md
+++ b/docs/setup-sensor/podman.md
@@ -41,6 +41,7 @@ If you'd like to run Orb with auto-updates and don't want to get into the detail
 mkdir -p /etc/containers/systemd
 curl -fsSL https://orb.net/docs/scripts/podman/orb-sensor.container -o /etc/containers/systemd/orb-sensor.container
 systemctl daemon-reload
+systemctl enable --now podman-auto-update.timer
 systemctl start orb-sensor
 podman exec -it orb-sensor /app/orb link
 ```
@@ -91,10 +92,11 @@ Quadlets are systemd unit files with a `.container` extension that define contai
 
 ## Step 2: Start the Orb Container
 
-1. Reload systemd to recognize the quadlet, then start the Orb sensor service:
+1. Reload systemd to recognize the quadlet, enable auto updates, and start the Orb sensor service:
 
    ```bash
    systemctl daemon-reload
+   systemctl enable --now podman-auto-update.timer
    systemctl start orb-sensor
    ```
 


### PR DESCRIPTION
# Pull Request

## What changes have you made?

Added command for enabling the systemd timer for controlling podman auto updates. `systemctl enable --now podman-auto-update.timer`

## Why are these changes helpful?

These changes are helpful because unless the user has previously enabled this timer the auto update functionality will not occur as expected. 

Since running orb via podman as originally described in #2, I recently realized that my images were not updating on their own. Confirmed that this change immediately fixed the issue. I typically run rootless podman and missed that this timer was not active for rootful podman.

## Related issues or considerations

#2 

## Checklist

- [x] Documentation is clear and understandable
- [x] No broken links or images
- [x] Follows project style and formatting
- [x] If scripts were modified/included, they have been tested and work as expected

## Additional notes

<!-- Any additional information that might be helpful -->

Please wait for feedback from the maintainers before merging.
