### PR TITLE
macOS Homebrew Orb Sensor install

### DIFF
--- a/docs/setup-sensor/README.md
+++ b/docs/setup-sensor/README.md
@@ -25,6 +25,7 @@ The best sensor device for you depends on your specific needs:
 ## Orb Sensor Setup Guides
 
 - [Linux](/docs/setup-sensor/linux)
+- [macOS](/docs/setup-sensor/macos.md)
 - [Raspberry Pi](/docs/setup-sensor/raspberry-pi.md)
 - [OpenWrt](/docs/setup-sensor/linux/openwrt.md)
 - [Docker](/docs/setup-sensor/docker.md)

--- a/docs/setup-sensor/macos.md
+++ b/docs/setup-sensor/macos.md
@@ -1,0 +1,36 @@
+---
+title: Install Orb on macOS
+shortTitle: macOS
+metaDescription: Install the Orb sensor on macOS via Homebrew
+section: setup-sensor
+layout: guides
+subtitle: 'Difficulty: Beginner 🧑‍💻'
+---
+
+# Install the Orb Sensor on macOS
+
+## Installation
+
+Setting up a macOS device as an Orb sensor can be done thanks to Homebrew with a single command:
+
+```bash
+brew install orbforge/orb/orb
+```
+
+If you don't have Homebrew installed, visit the [Homebrew site](https://brew.sh/) for up-to-date installation instructions. If you would prefer to run the Orb macOS app instead, view our [macOS installation guide](/docs/install-orb/macos.md).
+
+## Usage
+
+To start orbforge/orb/orb immediately and restart at login:
+
+```bash
+brew services start orbforge/orb/orb
+```
+
+If you don't want/need a background service or would likse to use other CLI functions, you can run:
+
+```bash
+/opt/homebrew/opt/orb/bin/orb help
+```
+
+for a list of available commands.

--- a/navigation.md
+++ b/navigation.md
@@ -18,6 +18,7 @@
 ## [Set up an Orb sensor](/docs/setup-sensor)
 
 - [Linux](/docs/setup-sensor/linux)
+- [macOS](/docs/setup-sensor/macos.md)
 - [Raspberry Pi](/docs/setup-sensor/raspberry-pi.md)
 - [OpenWrt](/docs/setup-sensor/linux/openwrt.md)
 - [Docker](/docs/setup-sensor/docker.md)


### PR DESCRIPTION
# Pull Request

## What changes have you made?

Instructions for installing via `brew`

## Why are these changes helpful?

Some macOS users want to run an Orb sensor without the desktop application. Homebrew is a more convenient way to install that using a binary, and has the advantages of built-in service and update handling.

## Related issues or considerations

N/A

## Checklist

- [x] Documentation is clear and understandable
- [x] No broken links or images
- [x] Follows project style and formatting
- [x] If scripts were modified/included, they have been tested and work as expected

## Additional notes

N/A

Please wait for feedback from the maintainers before merging.
