### PR TITLE
Fix 2 minor bugs on macOS install page

### DIFF
--- a/docs/install-orb/macos.md
+++ b/docs/install-orb/macos.md
@@ -22,12 +22,12 @@ This guide will walk you through the process of installing the Orb app on your M
 3. Tap "Get" to download the app
 4. Wait for the download and installation to complete
 
-### Step 3: Open the App
+### Step 2: Open the App
 
 1. Once the installation is complete, tap "Open" or alternatively, find the Orb app icon on your home screen and tap it
 2. Proceed through onboarding and permission requests
 
-### Step 4: Onboarding and Permissions
+### Step 3: Onboarding and Permissions
 
 When you first open the app, you will be guided through the onboarding process with a variety of information modals and permission requests:
 
@@ -53,7 +53,7 @@ If you're having trouble downloading the app:
 If the app downloads but won't open:
 
 1. Restart your device
-2. Check if iOS needs to be updated
+2. Check if macOS needs to be updated
 3. Delete and reinstall the app
 
 ## Next Steps


### PR DESCRIPTION
Fixed two issues  
-  Incorrect step labeling  
-  iOS instead of macOS

# Pull Request

## What changes have you made?

I noticed the macOS page had two errors: the incorrect labeling of the steps and a mistype from iOS, which should be macOS.

## Why are these changes helpful?

Clearer identifiable source page

## Related issues or considerations

N/A

## Checklist

- [x] Documentation is clear and understandable
- [X] No broken links or images
- [X] Follows project style and formatting
- [X] If scripts were modified/included, they have been tested and work as expected

## Additional notes

<!-- Any additional information that might be helpful -->

Please wait for feedback from the maintainers before merging.
