### PR TITLE
Update docker-compose.yml to include watchtower --cleanup

### DIFF
--- a/scripts/docker/docker-compose.yml
+++ b/scripts/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # Required to monitor other containers
-    command: --label-enable --scope orb --interval 3600 # Check for updates every hour (3600s)
+    command: --label-enable --scope orb --cleanup --interval 3600 # Check for updates every hour (3600s)
 
 volumes:
   orb-data: # Creates a named volume for persistent data


### PR DESCRIPTION
We added this to docker.md but not the docker-compose.yml in /scripts

# Pull Request

## What changes have you made?

Make docker-compose.yml aligned with docker.md

## Why are these changes helpful?

Ensure people using the docker-compose.yml directly get benefits of --cleanup flag in watchtower

## Related issues or considerations

https://github.com/orbforge/orb-docs/pull/32

## Checklist

- [x] Documentation is clear and understandable
- [x] No broken links or images
- [x] Follows project style and formatting
- [x] If scripts were modified/included, they have been tested and work as expected

## Additional notes

N/A

Please wait for feedback from the maintainers before merging.
