### PR TITLE
Document pre-install configuration for OpenWRT

### DIFF
--- a/docs/setup-sensor/gl-mt2500-standalone.md
+++ b/docs/setup-sensor/gl-mt2500-standalone.md
@@ -30,7 +30,7 @@ Before you begin, make sure you have:
 
 The Brume 2 ships with the OpenWRT operating system, which is pre-configured with many features to act as a router, VPN gateway, and more. For this guide, we'll create a new OpenWRT image that installs the Orb sensor and configures the device to connect to your network as a monitoring device.
 
-1. Visit the [OpenWRT Firmware Selector](https://firmware-selector.openwrt.org/?version=24.10.0&target=mediatek%2Ffilogic&id=glinet_gl-mt2500) for the Brume 2 GL-MT2500
+1. Visit the [OpenWRT Firmware Selector](https://firmware-selector.openwrt.org/?version=24.10.6&target=mediatek%2Ffilogic&id=glinet_gl-mt2500) for the Brume 2 GL-MT2500
 2. Click "Customize installed packages and/or first boot script" to expand the customization options
 
 ![Customize installed packages and/or first boot script](../../images/gl-mt2500/1.2.png)
@@ -84,6 +84,18 @@ mkdir /.config
 ln -s /overlay/orb /.config/orb
 
 echo "src/gz orb_packages $URL"  | tee -a /etc/opkg/customfeeds.conf
+
+# Optional: Customize Orb configuration before first launch
+# You can set a deployment token to automatically link this Orb to your Orb Space, or adjust other settings.
+# See the https://orb.net/docs/deploy-and-configure/configuration for all available options.
+# 
+# cat << EOF > /etc/config/orb
+# config orb 'orb'
+# 	list env 'ORB_DATA_DIR=/root'
+# 	list env 'ORB_EPHEMERAL_MODE=1'
+# 	list env 'ORB_LOG_CONSOLE_FORMAT=syslog'
+# 	list env 'ORB_DEPLOYMENT_TOKEN=<YOUR-DEPLOYMENT-TOKEN-HERE>'
+# EOF
 
 # Create orb-setup service
 cat << EOF > /etc/init.d/orb-setup

--- a/docs/setup-sensor/linux/openwrt.md
+++ b/docs/setup-sensor/linux/openwrt.md
@@ -41,7 +41,22 @@ Before you begin, make sure you have:
 3. If prompted about the authenticity of the host, type `yes` and press Enter.
 4. Enter the root password for your OpenWrt device when prompted. You should now have a command prompt logged into your OpenWrt device.
 
-## Step 2: Install Orb
+## Step 2: Pre-configure Orb (Optional)
+You can optionally create a configuration file to customize Orb behavior from the start. You can set a deployment token to automatically link this Orb to your Orb Space, or adjust other settings. See the [configuration docs](/docs/deploy-and-configure/configuration) for all available options.
+
+1. Create the configuration file:
+
+    ```bash
+    cat << EOF > /etc/config/orb
+    config orb 'orb'
+        list env 'ORB_DATA_DIR=/root'
+        list env 'ORB_EPHEMERAL_MODE=1'
+        list env 'ORB_LOG_CONSOLE_FORMAT=syslog'
+        list env 'ORB_DEPLOYMENT_TOKEN=<YOUR-DEPLOYMENT-TOKEN-HERE>'
+    EOF
+    ```
+
+## Step 3: Install Orb
 
 1. At the OpenWrt command prompt, run the following command exactly as shown:
 
@@ -57,7 +72,9 @@ Before you begin, make sure you have:
     - Enable auto-updates to keep Orb up-to-date.
 3. Wait for the script to complete. You should see output indicating the progress of the installation.
 
-## Step 3: Link your new Orb Sensor
+## Step 4: Link your new Orb Sensor (Optional)
+
+If you didn't configure a Deployment Token to auto-link your new Orb in Step 2, you can link it to your Orb Space now.
 
 1. Once the installation script finishes, the Orb Sensor should be running on your OpenWrt device.
 2. Open the Orb app on your phone or personal computer.
@@ -93,6 +110,18 @@ Add the Orb public key
 
 ```bash
 curl https://pkgs.orb.net/stable/openwrt/key.pub | tee /etc/opkg/keys/744a82bfef3c5690
+```
+
+Optionally, you can create a configuration file to customize Orb behavior from the start. You can set a deployment token to automatically link this Orb to your Orb Space, or adjust other settings. See the [configuration docs](/docs/deploy-and-configure/configuration) for all available options.
+
+```bash
+cat << EOF > /etc/config/orb
+config orb 'orb'
+    list env 'ORB_DATA_DIR=/root'
+    list env 'ORB_EPHEMERAL_MODE=1'
+    list env 'ORB_LOG_CONSOLE_FORMAT=syslog'
+    list env 'ORB_DEPLOYMENT_TOKEN=<YOUR-DEPLOYMENT-TOKEN-HERE>'
+EOF
 ```
 
 Install Orb


### PR DESCRIPTION
# Pull Request

## What changes have you made?

Document method for configuring an OpenWRT device with ENV variables.

## Why are these changes helpful?

This is a great way to pre-configure and auto-link a router to an Orb Space, and wasn't previously documented.

## Checklist

- [X] Documentation is clear and understandable
- [X] No broken links or images
- [X] Follows project style and formatting
- [X] If scripts were modified/included, they have been tested and work as expected

Please wait for feedback from the maintainers before merging.
