### PR TITLE
Fix table rendering issues in datasets docs

### DIFF
--- a/docs/deploy-and-configure/datasets.md
+++ b/docs/deploy-and-configure/datasets.md
@@ -117,7 +117,7 @@ Responsiveness data is available in 30 minute, 1 minute, and 1 second aggregated
 | `location_source` | Location Source<br>`0: unknown`<br>`1: geoip` | integer |
 | `measure_endpoint` | Measurement endpoint URL or IP address (only included when configured for Orb-to-Orb testing) | string |
 | `measure_endpoint_name` | Human-readable name of the measurement endpoint (only included when configured for Orb-to-Orb testing) | string |
-| `pingers` | List (CSV) of {protocol}|{endpoint}|{ipversion} strings of all active pingers (measurers) | string |
+| `pingers` | List (CSV) of {protocol}\|{endpoint}\|{ipversion} strings of all active pingers (measurers) | string |
 
 ## Web Responsiveness
 
@@ -135,7 +135,6 @@ Web Responsiveness measurements are conducted once per minute by default. Theref
 | `device_name`     | Hostname or name of the device as identified by the OS (masked unless identifiable=true)                                                                                                  | string  |
 | `orb_version`     | Semantic version of collecting Orb                                                                                                                                                        | string  |
 | `timestamp`       | Timestamp in epoch milliseconds                                                                                                                                                           | integer |
-
 | `dataset`         | Dataset type identifier                                                                                                                                                                   | string  |
 | **measures**      |                                                                                                                                                                                           |         |
 | `ttfb_us`         | Time to First Byte loading a web page in microseconds (MAX 5000000 at which point considered “unresponsive”)                                                                              | integer |
@@ -175,7 +174,6 @@ Content speed measurements are conducted once per hour by default. Therefore, ra
 | `device_name`       | Hostname or name of the device as identified by the OS (masked unless identifiable=true)                                                                                                  | string  |
 | `orb_version`       | Semantic version of collecting Orb                                                                                                                                                        | string  |
 | `timestamp`         | Timestamp in epoch milliseconds                                                                                                                                                           | integer |
-
 | `dataset`           | Dataset type identifier                                                                                                                                                                   | string  |
 | **measures**        |                                                                                                                                                                                           |         |
 | `download_kbps`     | Download speed in Kbps                                                                                                                                                                    | integer |


### PR DESCRIPTION
# Pull Request

## What changes have you made?

Fixes spacing and escaping issues causing datasets tables to render incorrectly.

## Why are these changes helpful?

Properly rendered tables are *much* easier to read.

## Checklist

- [X] Documentation is clear and understandable
- [X] No broken links or images
- [X] Follows project style and formatting
- [X] If scripts were modified/included, they have been tested and work as expected

Please wait for feedback from the maintainers before merging.
